### PR TITLE
Port to scraped

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -2,19 +2,12 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'nokogiri'
-require 'open-uri'
 require 'pry'
+require 'scraped'
 require 'scraperwiki'
 
 require 'open-uri/cached'
 OpenURI::Cache.cache_path = '.cache'
-
-class String
-  def tidy
-    gsub(/[[:space:]]+/, ' ').strip
-  end
-end
 
 def noko_for(url)
   Nokogiri::HTML(open(url).read)

--- a/scraper.rb
+++ b/scraper.rb
@@ -9,65 +9,126 @@ require 'scraperwiki'
 require 'open-uri/cached'
 OpenURI::Cache.cache_path = '.cache'
 
-def noko_for(url)
-  Nokogiri::HTML(open(url).read)
+class MembersPage < Scraped::HTML
+  field :members do
+    table.xpath('.//tr[td]').map do |tr|
+      fragment tr => MemberRow
+    end
+  end
+
+  private
+
+  def table
+    table = noko.xpath(".//table[.//th[contains(.,'Mitglied')]]")
+    raise "Can't find unique table of Members" unless table.count == 1
+    table.first
+  end
 end
 
-def month(str)
-  ['', 'januar', 'februar', 'märz', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'dezember'].find_index(str) or raise "Unknown month #{str}".magenta
-end
+class MemberRow < Scraped::HTML
+  field :id do
+    wikiname.downcase.tr(' ', '_')
+  end
 
-def date_from(dd, mm, yy)
-  '%02d-%02d-%02d' % [yy, month(mm.downcase), dd]
+  field :name do
+    tds[0].css('a').first.text.tidy
+  end
+
+  field :sort_name do
+    tds[0].css('@data-sort-value').text.tidy
+  end
+
+  field :party do
+    tds[2].text.tidy
+  end
+
+  field :constituency do
+    tds[4].text.tidy rescue ''
+  end
+
+  field :area do
+    tds[3].text.tidy
+  end
+
+  field :term do
+    id
+  end
+
+  field :wikiname do
+    tds[0].css('a/@title').first.text
+  end
+
+  field :source do
+    url
+  end
+
+  field :notes do
+    tds[6].text.tidy unless tds[6].nil?
+  end
+
+  field :start_date do
+    return unless notes
+    return unless matched = notes.downcase.match(/eingetreten.*?am #{DATE_RE}/) ||
+                            notes.downcase.match(/nachgewählt am #{DATE_RE}/)
+    sort_date || date_from(*matched.captures)
+  end
+
+  field :end_date do
+    return death_date unless death_date.to_s.empty?
+    return unless notes
+    return unless matched = notes.downcase.match(/ausgeschieden.*?am #{DATE_RE}/)
+    sort_date || date_from(*matched.captures)
+  end
+
+  field :death_date do
+    return unless notes
+    return unless matched = notes.downcase.match(/verstorben.*?am #{DATE_RE}/)
+    sort_date || date_from(*matched.captures)
+  end
+
+  private
+
+  DATE_RE = '(\d+)\.?\s+([^ ]+)\s+(\d+)'
+
+  MONTHS = %w(_nil januar februar märz april mai juni juli august september oktober november dezember).freeze
+
+  def tds
+    noko.css('td')
+  end
+
+  def month(str)
+    MONTHS.find_index(str) or raise "Unknown month #{str}"
+  end
+
+  def date_from(dd, mm, yy)
+    '%02d-%02d-%02d' % [yy, month(mm.downcase), dd]
+  end
+
+  def sort_date
+    sortkey = tds[6].css('span.sortkey') if notes
+    Date.parse(sortkey.text).to_s rescue nil
+  end
+
+  # TODO: other notes
+  # elsif matched = notes.downcase.match(/bis zum #{DATE_RE} .*/)
+  # TODO: old_name = matched.captures.pop
+  # elsif matched = notes.downcase.match(/#{DATE_RE} aus der fraktion (.*) ausgeschieden/)
+  # TODO: left faktion
+  # elsif matched = notes.downcase.match(/seit #{DATE_RE} fraktionslos/)
+  # TODO: left faktion
+  # elsif matched = notes.downcase.match(/ab #{DATE_RE} fraktionslos/) ||
+  #   notes.downcase.match(/fraktionslos ab #{DATE_RE}/)
+  # TODO: left faktion
+  # elsif notes.include?('nahm sein Mandat nicht an') || notes.include?('Mandat nicht angenommen')
+  # TODO: didn't accept mandate
 end
 
 def scrape_term(id, url)
-  noko = noko_for(url)
-  table = noko.xpath(".//table[.//th[contains(.,'Mitglied')]]")
-  raise "Can't find unique table of Members" unless table.count == 1
-  table.xpath('.//tr[td]').each do |tr|
-    tds = tr.css('td')
-    constituency = tds[4].text.tidy rescue ''
-    wikiname = tds[0].css('a/@title').first.text
-    data = {
-      id:           wikiname.downcase.tr(' ', '_'),
-      name:         tds[0].css('a').first.text.tidy,
-      sort_name:    tds[0].css('@data-sort-value').text.tidy,
-      party:        tds[2].text.tidy,
-      constituency: constituency,
-      area:         tds[3].text.tidy,
-      term:         id,
-      wikiname:     wikiname,
-      source:       url,
-    }
-
-    unless tds[6].nil? || (notes = tds[6].text.tidy).empty?
-      data[:notes] = notes
-      if sort_date = tds[6].css('span.sortkey')
-        sort_date = Date.parse(sort_date.text).to_s rescue nil
-      end
-      date_re = '(\d+)\.?\s+([^ ]+)\s+(\d+)'
-      if matched = notes.downcase.match(/ausgeschieden.*?am #{date_re}/)
-        data[:end_date] = sort_date || date_from(*matched.captures)
-      elsif matched = notes.downcase.match(/eingetreten.*?am #{date_re}/) || notes.downcase.match(/nachgewählt am #{date_re}/)
-        data[:start_date] = sort_date || date_from(*matched.captures)
-      elsif matched = notes.downcase.match(/verstorben.*?am #{date_re}/)
-        data[:death_date] = data[:end_date] = sort_date || date_from(*matched.captures)
-      elsif matched = notes.downcase.match(/bis zum #{date_re} .*/)
-        # TODO: old_name = matched.captures.pop
-      elsif matched = notes.downcase.match(/#{date_re} aus der fraktion (.*) ausgeschieden/)
-        # TODO: left faktion
-      elsif matched = notes.downcase.match(/seit #{date_re} fraktionslos/)
-        # TODO: left faktion
-      elsif matched = notes.downcase.match(/ab #{date_re} fraktionslos/) || notes.downcase.match(/fraktionslos ab #{date_re}/)
-        # TODO: left faktion
-      elsif notes.include?('nahm sein Mandat nicht an') || notes.include?('Mandat nicht angenommen')
-        # TODO: didn't accept mandate
-      end
-    end
-    # puts data
-    ScraperWiki.save_sqlite(%i(id term), data)
+  data = MembersPage.new(response: Scraped::Request.new(url: url).response).members.map do |mem|
+    mem.to_h.merge(term: id)
   end
+  # data.each { |m| puts m.reject { |_k, v| v.to_s.empty? }.sort_by { |k, _v| k }.to_h }
+  ScraperWiki.save_sqlite(%i(id term), data)
 end
 
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil


### PR DESCRIPTION
This is the naive port directly across — we still need to tidy it up more.

As a bonus, we now get both the start_date and end_date of memberships that both start and end mid-term. Previously we were only getting the end_date